### PR TITLE
Update README.md to add supported device

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This code is base on version 4.3.14 from https://github.com/diederikdehaas/rtl88
 ## Known Supported Devices:
 
 ```
-* COMFAST 1200Mbps USB Wireless Adapter(Model: CF-912AC)
+* COMFAST 1200Mbps USB Wireless Adapter (Model: CF-912AC)
+* OURLINK 600Mbps mini 802.11ac Dual Band 2.4G/5G Wireless Network Adapter (Model 6436305)
 ```
 
 ## Compiling with DKMS


### PR DESCRIPTION
I own the OURLINK 600Mbps mini 802.11ac Dual Band 2.4G/5G Wireless Network Adapter (Model 6436305) device ([amazon link](https://smile.amazon.com/gp/product/B018TX8IDA/ref=oh_aui_search_detailpage?ie=UTF8&psc=1)). This driver installed and worked for me on Ubuntu 16.04 w/ 4.10 kernel.